### PR TITLE
Change AppInsights `type` in the manifest

### DIFF
--- a/src/AzureServices/AppInsightsBuilderExtensions.cs
+++ b/src/AzureServices/AppInsightsBuilderExtensions.cs
@@ -15,7 +15,7 @@ public static class AppInsightsBuilderExtensions
 
     static void WriteAppInsightsResourceToManifest(Utf8JsonWriter jsonWriter, string? connectionString)
     {
-        jsonWriter.WriteString("type", "azure.appinsights.v1");
+        jsonWriter.WriteString("type", "azure.appinsights.v0");
         if (!string.IsNullOrEmpty(connectionString))
         {
             jsonWriter.WriteString("connectionString", connectionString);


### PR DESCRIPTION
Before Preview 1 of Aspire and `azd` we made a change such that all the resource types were `.v0` instead of `.v1`.

That change didn't happen in the manifest writer for the App Insights resource because we only did passes over the Aspire and `azd` repositories.

This fixes the manifest writer to write the type that `azd` expects. With this change you can now `azd init` and `azd provision` this sample.