### PR TITLE
enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,5 @@ updates:
       - public-nuget
     schedule:
       interval: weekly
-    open-pull-requests-limit: 15      
+    open-pull-requests-limit: 15
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
       interval: weekly
     open-pull-requests-limit: 15
     groups:
+      Aspire:
+        patterns:
+          - "Aspire.*"
+          - "Microsoft.Extensions.ServiceDiscovery.*"
       Azure:
         patterns:
           - "Azure.*"
@@ -27,6 +31,7 @@ updates:
       MicrosoftExtensions:
         patterns:
           - "Microsoft.Extensions.*"
+          - "Microsoft.Bcl.*"
       EntityFrameworkCore:
         patterns:
           - "Microsoft.EntityFrameworkCore.*"
@@ -45,3 +50,10 @@ updates:
       Grpc:
         patterns:
           - "Grpc.*"
+      Pgvector:
+        patterns:
+          - "Pgvector.*"
+      Duende:
+        patterns:
+          - "Duende.*"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,37 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 15
-
+    groups:
+      Azure:
+        patterns:
+          - "Azure.*"
+          - "Microsoft.Azure.*"
+          - "Microsoft.Extensions.Azure"
+      AspNetCoreHealthChecks:
+        patterns:
+          - "AspNetCore.HealthChecks.*"
+      AspNetCore:
+        patterns:
+          - "Microsoft.AspNetCore.*"
+          - "Microsoft.Extensions.Features"
+      MicrosoftExtensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      EntityFrameworkCore:
+        patterns:
+          - "Microsoft.EntityFrameworkCore.*"
+      FluentUi:
+        patterns:
+          - "Microsoft.FluentUI.*"
+      OpenTelemetry:
+        patterns:
+          - "OpenTelemetry.*"
+      Npgsql:
+        patterns:
+          - "Npgsql.*"
+      MicrosoftDotNet:
+        patterns:
+          - "Microsoft.DotNet.*"
+      Grpc:
+        patterns:
+          - "Grpc.*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     registries:
       - public-nuget
     schedule:
-      interval: weekly
+      interval: daily
     open-pull-requests-limit: 15
     groups:
       Aspire:


### PR DESCRIPTION
Take 2. Validated to work in my fork.

(For the groups list I'm just going to share with other repos, it doesn't matter that Fluent isn't used in this repo.)